### PR TITLE
Bug: Error "SQLSTATE[HY093]: Invalid parameter number: number of boun…

### DIFF
--- a/DisableTracking.php
+++ b/DisableTracking.php
@@ -100,11 +100,14 @@
 
             if (count($siteIds) !== 0) {
                 $sql .= 'AND `siteId` NOT IN (?)';
+                $binds = join(',', $siteIds);
+            } else {
+                $binds = [];
             }
 
             Db::query(
                 $sql,
-                join(',', $siteIds)
+                $binds
             );
         }
 


### PR DESCRIPTION
I was getting Error "SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens" when only a site is configured and state changed from disabled to enabled.
The problem was that, in that case, `join` in line 107 returns an empty string, so `DB:query` inner code considers there is a bind parameter, so the error above is generated. The solution I've chosen is to pass an empty array explicitly when there's no siteIds.
Hope it helps.
By the way, good job.